### PR TITLE
chore: add agent tool skills and OpenCode configuration

### DIFF
--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -1,0 +1,1 @@
+../../.agents/skills/commit/SKILL.md

--- a/.claude/skills/pr.md
+++ b/.claude/skills/pr.md
@@ -1,0 +1,1 @@
+../../.agents/skills/pr/SKILL.md

--- a/.claude/skills/validate.md
+++ b/.claude/skills/validate.md
@@ -1,0 +1,1 @@
+../../.agents/skills/validate/SKILL.md

--- a/.opencode/commands/commit.md
+++ b/.opencode/commands/commit.md
@@ -1,0 +1,1 @@
+../../.agents/skills/commit/SKILL.md

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -1,0 +1,1 @@
+../../.agents/skills/pr/SKILL.md

--- a/.opencode/commands/validate.md
+++ b/.opencode/commands/validate.md
@@ -1,0 +1,1 @@
+../../.agents/skills/validate/SKILL.md

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "just lint": "allow",
+      "just fmt": "allow",
+      "just test-unit": "allow",
+      "just test-unit *": "allow",
+      "just check": "allow",
+      "just install": "allow",
+      "just build": "allow",
+      "poetry add *": "allow",
+      "poetry remove *": "allow",
+      "gh pr create *": "allow",
+      "gh label create *": "allow",
+      "gh label list *": "allow"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/skills/` symlinks to `.agents/skills/` so Claude Code discovers `/validate`, `/commit`, and `/pr` slash commands
- Add `.opencode/commands/` symlinks to `.agents/skills/` so OpenCode discovers the same slash commands
- Add `opencode.json` with bash permission settings mirroring `.claude/settings.json`

## Test plan
- [ ] Verify `.claude/skills/` symlinks resolve: `ls -la .claude/skills/`
- [ ] Verify `.opencode/commands/` symlinks resolve: `ls -la .opencode/commands/`
- [ ] Verify `opencode.json` is valid JSON: `python3 -m json.tool opencode.json`
- [ ] Confirm `/validate`, `/commit`, `/pr` appear as slash commands in Claude Code
- [ ] Confirm `/validate`, `/commit`, `/pr` appear as slash commands in OpenCode